### PR TITLE
Icon visible if fonts are overridden, show forced line-breaks

### DIFF
--- a/assets/editor/editor.css
+++ b/assets/editor/editor.css
@@ -28,7 +28,7 @@ you can use the generic selector below, but it's slower:
 [class*="icon-"] {
 */
 .icon-bold, .icon-italic, .icon-quote, .icon-unordered-list, .icon-ordered-list, .icon-link, .icon-image, .icon-play, .icon-music, .icon-contract, .icon-fullscreen, .icon-question, .icon-info, .icon-undo, .icon-redo, .icon-code, .icon-preview, .icon-emaillink, .icon-map {
-  font-family: 'icomoon';
+  font-family: 'icomoon'!important;
   speak: none;
   font-style: normal;
   font-weight: normal;
@@ -172,6 +172,11 @@ you can use the generic selector below, but it's slower:
 div.CodeMirror span.CodeMirror-matchingbracket {color: #0f0;}
 div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 
+/* forced line-breaks */
+.cm-trailing-space-new-line:after {
+content: '¬';
+color: red;
+}
 
 /* STOP */
 


### PR DESCRIPTION
Added »!important« for icon-font to override possible
css-font-overrides by the backend_add_script extension.

Added style for forced line-breaks via double trailing spaces.
