### PR TITLE
Updated editor.css to remove `height` spec

### DIFF
--- a/assets/editor/editor.css
+++ b/assets/editor/editor.css
@@ -62,9 +62,6 @@
 
 /* BASICS */
 
-.CodeMirror {
-  height: 300px;
-}
 .CodeMirror-scroll {
   /* Set scrolling behaviour here */
   overflow: auto;
@@ -270,9 +267,6 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   .CodeMirror div.CodeMirror-cursor {
     visibility: hidden;
   }
-}
-.CodeMirror {
-  height: 450px;
 }
 :-webkit-full-screen {
   background: #f9f9f5;


### PR DESCRIPTION
`editor.css` has two CSS `height` declarations that are not helpful when using Markdown for a small textarea box in the sidebar. These changes make it look much better in this context:

![screenshot](http://cl.ly/image/3Q223a3q2x0N/Image%202014-08-01%20at%201.46.27%20PM.png)
