### PR TITLE
Better defaults for .primary + .secondary contexts

### DIFF
--- a/assets/editor/editor.css
+++ b/assets/editor/editor.css
@@ -62,8 +62,11 @@
 
 /* BASICS */
 
-.CodeMirror {
-  height: 300px;
+.primary .CodeMirror {
+  height: 450px;
+}
+.secondary .CodeMirror {
+  height: 150px;
 }
 .CodeMirror-scroll {
   /* Set scrolling behaviour here */
@@ -270,9 +273,6 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   .CodeMirror div.CodeMirror-cursor {
     visibility: hidden;
   }
-}
-.CodeMirror {
-  height: 450px;
 }
 :-webkit-full-screen {
   background: #f9f9f5;


### PR DESCRIPTION
When `editor_for_symphony` is enabled and a `textarea` field is in the sidebar, the default height of 450px is long. Like really, really long:

![screen shot 2014-08-01 at 2 03 53 pm](https://cloud.githubusercontent.com/assets/275617/3785122/ce6f4630-19bf-11e4-8c46-c317ad91e5ef.png)

This makes it better suited in the sidebar context while still giving proper treatment in the `.primary` column:

![screen shot 2014-08-01 at 2 04 11 pm](https://cloud.githubusercontent.com/assets/275617/3785125/d8475a4e-19bf-11e4-84d7-8ec6a0e34e9a.png)
